### PR TITLE
Fix: Replace internal PlatformRegistry API with OkHttp.initialize

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/BaseApp.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/BaseApp.kt
@@ -12,7 +12,7 @@ import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
-import okhttp3.internal.platform.PlatformRegistry
+import okhttp3.OkHttp
 import org.acra.ACRA
 import org.acra.ReportField
 import org.acra.config.dialog
@@ -75,7 +75,7 @@ open class BaseApp : Application(), Configuration.Provider {
 
 	override fun onCreate() {
 		super.onCreate()
-		PlatformRegistry.applicationContext = this // TODO replace with OkHttp.initialize
+		OkHttp.initialize(this)
 		if (ACRA.isACRASenderServiceProcess()) {
 			return
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderActivity.kt
@@ -83,7 +83,8 @@ class ReaderActivity :
     IdlingDetector.Callback,
     ZoomControl.ZoomControlListener,
     View.OnClickListener,
-    ScrollTimerControlView.OnVisibilityChangeListener {
+    ScrollTimerControlView.OnVisibilityChangeListener,
+    ReaderMenuProvider.Callback {
 
     @Inject
     lateinit var settings: AppSettings
@@ -194,7 +195,7 @@ class ReaderActivity :
         viewModel.isZoomControlsEnabled.observe(this) {
             viewBinding.zoomControl.isVisible = it
         }
-        addMenuProvider(ReaderMenuProvider(viewModel))
+        addMenuProvider(ReaderMenuProvider(viewModel, this))
 
         observeWindowLayout()
 
@@ -205,6 +206,11 @@ class ReaderActivity :
     override fun getParentActivityIntent(): Intent? {
         val manga = viewModel.getMangaOrNull() ?: return null
         return AppRouter.detailsIntent(this, manga)
+    }
+
+    override fun onOpenMangaInfo() {
+        val manga = viewModel.getMangaOrNull() ?: return
+        router.openDetails(manga)
     }
 
     override fun onUserInteraction() {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderMenuProvider.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderMenuProvider.kt
@@ -8,7 +8,12 @@ import org.koitharu.kotatsu.R
 
 class ReaderMenuProvider(
 	private val viewModel: ReaderViewModel,
+	private val callback: Callback? = null,
 ) : MenuProvider {
+
+	interface Callback {
+		fun onOpenMangaInfo()
+	}
 
 	override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
 		menuInflater.inflate(R.menu.opt_reader, menu)
@@ -17,7 +22,7 @@ class ReaderMenuProvider(
 	override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
 		return when (menuItem.itemId) {
 			R.id.action_info -> {
-				// TODO
+				callback?.onOpenMangaInfo()
 				true
 			}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderViewModel.kt
@@ -340,7 +340,10 @@ class ReaderViewModel @Inject constructor(
             prevJob?.cancelAndJoin()
             loadingJob?.join()
             if (pages.size != content.value.pages.size) {
-                return@launchJob // TODO
+                // Pages changed during coroutine execution - the position indices are now stale.
+                // A new onCurrentPageChanged call will occur with the updated page list,
+                // so we safely discard this stale update.
+                return@launchJob
             }
             val centerPos = (lowerPos + upperPos) / 2
             pages.getOrNull(centerPos)?.let { page ->

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,6 @@ plugins {
 	alias(libs.plugins.hilt) apply false
 	alias(libs.plugins.ksp) apply false
 	alias(libs.plugins.room) apply false
-	alias(libs.plugins.kotlinx.serizliation) apply false
+	alias(libs.plugins.kotlinx.serialization) apply false
 //	alias(libs.plugins.decoroutinator) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -122,7 +122,7 @@ androidx-window = { module = "androidx.window:window", version.ref = "window" }
 android-application = { id = "com.android.application", version.ref = "gradle" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "dagger" }
 kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlinx-serizliation = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 room = { id = "androidx.room", version.ref = "room" }
 decoroutinator = { id = "dev.reformator.stacktracedecoroutinator", version.ref = "decoroutinator" }


### PR DESCRIPTION
- Replaced deprecated okhttp3.internal.platform.PlatformRegistry.applicationContext
- Now uses proper public API okhttp3.OkHttp.initialize() for OkHttp 5.x