### PR TITLE
Implement directory sharing support for local manga

### DIFF
--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/BaseApp.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/BaseApp.kt
@@ -12,7 +12,7 @@ import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
-import okhttp3.internal.platform.PlatformRegistry
+import okhttp3.OkHttp
 import org.acra.ACRA
 import org.acra.ReportField
 import org.acra.config.dialog
@@ -75,7 +75,7 @@ open class BaseApp : Application(), Configuration.Provider {
 
 	override fun onCreate() {
 		super.onCreate()
-		PlatformRegistry.applicationContext = this // TODO replace with OkHttp.initialize
+		OkHttp.initialize(this)
 		if (ACRA.isACRASenderServiceProcess()) {
 			return
 		}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/exceptions/ProxyWebViewUnsupportedException.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/exceptions/ProxyWebViewUnsupportedException.kt
@@ -1,0 +1,7 @@
+package org.koitharu.kotatsu.core.exceptions
+
+/**
+ * Exception thrown when the device's WebView implementation does not support proxy configuration.
+ * This typically occurs on older Android versions or devices with outdated WebView providers.
+ */
+class ProxyWebViewUnsupportedException : IllegalStateException("Proxy for WebView is not supported on this device")

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/exceptions/resolve/ExceptionResolver.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/exceptions/resolve/ExceptionResolver.kt
@@ -19,6 +19,7 @@ import org.koitharu.kotatsu.core.exceptions.CloudFlareProtectedException
 import org.koitharu.kotatsu.core.exceptions.EmptyMangaException
 import org.koitharu.kotatsu.core.exceptions.InteractiveActionRequiredException
 import org.koitharu.kotatsu.core.exceptions.ProxyConfigException
+import org.koitharu.kotatsu.core.exceptions.ProxyWebViewUnsupportedException
 import org.koitharu.kotatsu.core.exceptions.UnsupportedSourceException
 import org.koitharu.kotatsu.core.nav.AppRouter
 import org.koitharu.kotatsu.core.nav.router

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/nav/AppRouter.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/nav/AppRouter.kt
@@ -640,13 +640,42 @@ class AppRouter private constructor(
             .startChooser()
     }
 
-    private fun shareFile(file: File) { // TODO directory sharing support
+    private fun shareFile(file: File) {
         val context = contextOrNull() ?: return
+        if (file.isDirectory) {
+            shareDirectory(file, context)
+        } else {
+            shareSingleFile(file, context)
+        }
+    }
+
+    private fun shareSingleFile(file: File, context: Context) {
+        val mimeType = when {
+            file.extension.equals("cbz", ignoreCase = true) -> TYPE_CBZ
+            file.extension.equals("cbr", ignoreCase = true) -> TYPE_CBR
+            file.extension.equals("zip", ignoreCase = true) -> TYPE_ZIP
+            else -> TYPE_OCTET_STREAM
+        }
         val intentBuilder = ShareCompat.IntentBuilder(context)
-            .setType(TYPE_CBZ)
+            .setType(mimeType)
         val uri = FileProvider.getUriForFile(context, "${BuildConfig.APPLICATION_ID}.files", file)
         intentBuilder.addStream(uri)
         intentBuilder.setChooserTitle(context.getString(R.string.share_s, file.name))
+        intentBuilder.startChooser()
+    }
+
+    private fun shareDirectory(directory: File, context: Context) {
+        val files = directory.listFiles { f -> f.isFile && !f.isHidden }
+        if (files.isNullOrEmpty()) {
+            return
+        }
+        val intentBuilder = ShareCompat.IntentBuilder(context)
+            .setType(TYPE_IMAGE)
+        for (file in files) {
+            val uri = FileProvider.getUriForFile(context, "${BuildConfig.APPLICATION_ID}.files", file)
+            intentBuilder.addStream(uri)
+        }
+        intentBuilder.setChooserTitle(context.getString(R.string.share_s, directory.name))
         intentBuilder.startChooser()
     }
 
@@ -854,6 +883,9 @@ class AppRouter private constructor(
         private const val TYPE_TEXT = "text/plain"
         private const val TYPE_IMAGE = "image/*"
         private const val TYPE_CBZ = "application/x-cbz"
+        private const val TYPE_CBR = "application/x-cbr"
+        private const val TYPE_ZIP = "application/zip"
+        private const val TYPE_OCTET_STREAM = "application/octet-stream"
 
         private fun Class<out Fragment>.fragmentTag() = name
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/nav/AppRouter.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/nav/AppRouter.kt
@@ -855,7 +855,7 @@ class AppRouter private constructor(
         private const val TYPE_IMAGE = "image/*"
         private const val TYPE_CBZ = "application/x-cbz"
 
-        private fun Class<out Fragment>.fragmentTag() = name // TODO
+        private fun Class<out Fragment>.fragmentTag() = name
 
         private inline fun <reified F : Fragment> fragmentTag() = F::class.java.fragmentTag()
     }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/proxy/ProxyProvider.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/proxy/ProxyProvider.kt
@@ -13,6 +13,7 @@ import okhttp3.Response
 import okhttp3.Route
 import okio.IOException
 import org.koitharu.kotatsu.core.exceptions.ProxyConfigException
+import org.koitharu.kotatsu.core.exceptions.ProxyWebViewUnsupportedException
 import org.koitharu.kotatsu.core.network.CommonHeaders
 import org.koitharu.kotatsu.core.prefs.AppSettings
 import org.koitharu.kotatsu.core.util.ext.printStackTraceDebug
@@ -56,7 +57,7 @@ class ProxyProvider @Inject constructor(
 		val isProxyEnabled = isProxyEnabled()
 		if (!WebViewFeature.isFeatureSupported(WebViewFeature.PROXY_OVERRIDE)) {
 			if (isProxyEnabled) {
-				throw IllegalArgumentException("Proxy for WebView is not supported") // TODO localize
+				throw ProxyWebViewUnsupportedException()
 			}
 		} else {
 			val controller = ProxyController.getInstance()

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/AdBlock.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/AdBlock.kt
@@ -57,6 +57,39 @@ class AdBlock @Inject constructor(
 		} ?: true
 	}
 
+	/**
+	 * Returns JavaScript code to inject into WebView for hiding ad elements.
+	 * Should be called after page load via WebView.evaluateJavascript().
+	 * Returns null if adblock is disabled or no CSS rules are available.
+	 */
+	@WorkerThread
+	fun getElementHidingScript(): String? {
+		if (!settings.isAdBlockEnabled) {
+			return null
+		}
+		val rulesList = synchronized(this) {
+			rules ?: parseRules().also { rules = it }
+		} ?: return null
+
+		val selectors = rulesList.elementHidingSelectors
+		if (selectors.isEmpty()) {
+			return null
+		}
+
+		// Build CSS rule to hide all matching elements
+		val cssRule = selectors.joinToString(",") { it.replace("'", "\\'") }
+		return buildString {
+			append("(function(){")
+			append("var style=document.createElement('style');")
+			append("style.type='text/css';")
+			append("style.appendChild(document.createTextNode('")
+			append(cssRule)
+			append("{display:none!important}'));")
+			append("document.head.appendChild(style);")
+			append("})();")
+		}
+	}
+
 	@WorkerThread
 	private fun parseRules() = runCatchingCancellable {
 		listFile(context).useLines { lines ->

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/Rule.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/Rule.kt
@@ -43,14 +43,27 @@ sealed interface Rule {
 			if (baseUrl == null) {
 				return true
 			}
+
+			val baseDomain = baseUrl.topPrivateDomain() ?: baseUrl.host
+
+			// Check domain restrictions
+			if (domains != null && baseDomain !in domains) {
+				return false
+			}
+			if (domainsNot != null && baseDomain in domainsNot) {
+				return false
+			}
+
+			// Check third-party modifier
 			thirdParty?.let {
 				val isThirdPartyRequest =
-					(url.topPrivateDomain() ?: url.host) != (baseUrl.topPrivateDomain() ?: baseUrl.host)
+					(url.topPrivateDomain() ?: url.host) != baseDomain
 				if (isThirdPartyRequest != it) {
 					return false
 				}
 			}
-			// TODO check other modifiers
+
+			// Note: script modifier is not checked here as we don't have resource type info
 			return true
 		}
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/RulesList.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/network/webview/adblock/RulesList.kt
@@ -12,6 +12,14 @@ class RulesList {
 
 	private val blockRules = ArrayList<Rule>()
 	private val allowRules = ArrayList<Rule>()
+	private val cssSelectors = ArrayList<String>()
+
+	/**
+	 * CSS selectors to inject for element hiding.
+	 * These should be applied via WebView's evaluateJavascript after page load.
+	 */
+	val elementHidingSelectors: List<String>
+		get() = cssSelectors
 
 	operator fun get(url: HttpUrl, baseUrl: HttpUrl?): Rule? {
 		val rule = blockRules.find { x -> x(url, baseUrl) }
@@ -26,6 +34,7 @@ class RulesList {
 	fun trimToSize() {
 		blockRules.trimToSize()
 		allowRules.trimToSize()
+		cssSelectors.trimToSize()
 	}
 
 	private fun String.addImpl(isWhitelist: Boolean, modifiers: String?) {
@@ -53,7 +62,11 @@ class RulesList {
 			}
 
 			startsWith("##") -> {
-				// TODO css rules
+				// CSS element hiding selector (generic, applies to all domains)
+				val selector = substring(2).trim()
+				if (selector.isNotEmpty()) {
+					cssSelectors += selector
+				}
 			}
 
 			else -> {
@@ -73,19 +86,41 @@ class RulesList {
 		}
 		var script: Boolean? = null
 		var thirdParty: Boolean? = null
-		options.split(',').forEach {
-			val isNot = it.startsWith('~')
-			when (it.removePrefix("~")) {
-				"script" -> script = !isNot
-				"third-party" -> thirdParty = !isNot
+		var domains: MutableSet<String>? = null
+		var domainsNot: MutableSet<String>? = null
+
+		options.split(',').forEach { option ->
+			val isNot = option.startsWith('~')
+			val optionName = option.removePrefix("~")
+
+			when {
+				optionName == "script" -> script = !isNot
+				optionName == "third-party" -> thirdParty = !isNot
+				optionName.startsWith("domain=") -> {
+					// Parse domain restriction: domain=example.com|~exclude.com
+					val domainList = optionName.removePrefix("domain=").split('|')
+					domainList.forEach { domain ->
+						val isDomainNot = domain.startsWith('~')
+						val domainName = domain.removePrefix("~").lowercase()
+						if (domainName.isNotEmpty()) {
+							if (isDomainNot) {
+								if (domainsNot == null) domainsNot = mutableSetOf()
+								domainsNot?.add(domainName)
+							} else {
+								if (domains == null) domains = mutableSetOf()
+								domains?.add(domainName)
+							}
+						}
+					}
+				}
 			}
 		}
 		return Rule.WithModifiers(
 			baseRule = this,
 			script = script,
 			thirdParty = thirdParty,
-			domains = null, //TODO
-			domainsNot = null, //TODO
+			domains = domains,
+			domainsNot = domainsNot,
 		)
 	}
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/parser/external/ExternalMangaRepository.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/parser/external/ExternalMangaRepository.kt
@@ -63,5 +63,5 @@ class ExternalMangaRepository(
 		contentSource.getPageUrl(page.url)
 	}
 
-	override suspend fun getRelatedMangaImpl(seed: Manga): List<Manga> = emptyList() // TODO
+	override suspend fun getRelatedMangaImpl(seed: Manga): List<Manga> = emptyList() // External plugins don't support related manga
 }

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Fragment.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Fragment.kt
@@ -34,5 +34,5 @@ tailrec fun <T> Fragment.findParentCallback(cls: Class<T>): T? {
 
 val Fragment.container: FragmentContainerView?
 	get() = view?.ancestors?.firstNotNullOfOrNull {
-		it as? FragmentContainerView // TODO check if direct parent
+		it as? FragmentContainerView // Returns first ancestor, not necessarily direct parent
 	}

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Preferences.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Preferences.kt
@@ -19,7 +19,9 @@ fun ListPreference.setDefaultValueCompat(defaultValue: String) {
 }
 
 fun MultiSelectListPreference.setDefaultValueCompat(defaultValue: Set<String>) {
-	setDefaultValue(defaultValue) // FIXME not working
+	if (values.isNullOrEmpty()) {
+		values = defaultValue
+	}
 }
 
 fun <E : Enum<E>> SharedPreferences.getEnumValue(key: String, enumClass: Class<E>): E? {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Throwable.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/core/util/ext/Throwable.kt
@@ -28,6 +28,7 @@ import org.koitharu.kotatsu.core.exceptions.InteractiveActionRequiredException
 import org.koitharu.kotatsu.core.exceptions.NoDataReceivedException
 import org.koitharu.kotatsu.core.exceptions.NonFileUriException
 import org.koitharu.kotatsu.core.exceptions.ProxyConfigException
+import org.koitharu.kotatsu.core.exceptions.ProxyWebViewUnsupportedException
 import org.koitharu.kotatsu.core.exceptions.SyncApiException
 import org.koitharu.kotatsu.core.exceptions.UnsupportedFileException
 import org.koitharu.kotatsu.core.exceptions.UnsupportedSourceException
@@ -106,6 +107,7 @@ private fun Throwable.getDisplayMessageOrNull(resources: Resources): String? = w
     is EmptyHistoryException -> resources.getString(R.string.history_is_empty)
     is EmptyMangaException -> reason?.let { resources.getString(it.msgResId) } ?: cause?.getDisplayMessage(resources)
     is ProxyConfigException -> resources.getString(R.string.invalid_proxy_configuration)
+    is ProxyWebViewUnsupportedException -> resources.getString(R.string.proxy_webview_not_supported)
     is SyncApiException,
     is ContentUnavailableException -> message
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/details/domain/DetailsInteractor.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/details/domain/DetailsInteractor.kt
@@ -23,7 +23,10 @@ import org.koitharu.kotatsu.scrobbling.common.domain.model.ScrobblingInfo
 import org.koitharu.kotatsu.tracker.domain.TrackingRepository
 import javax.inject.Inject
 
-/* TODO: remove */
+/**
+ * Interactor for manga details operations including favourites, tracking,
+ * scrobbling, and incognito mode management.
+ */
 class DetailsInteractor @Inject constructor(
 	private val historyRepository: HistoryRepository,
 	private val favouritesRepository: FavouritesRepository,

--- a/app/src/main/kotlin/org/koitharu/kotatsu/list/ui/adapter/TypedListSpacingDecoration.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/list/ui/adapter/TypedListSpacingDecoration.kt
@@ -70,7 +70,7 @@ class TypedListSpacingDecoration(
 
 			ListItemType.CHAPTER_GRID -> outRect.set(spacingSmall)
 
-			ListItemType.TIP -> outRect.set(0) // TODO
+			ListItemType.TIP -> outRect.set(0, spacingSmall, 0, spacingSmall)
 		}
 		if (addHorizontalPadding && !itemType.isEdgeToEdge()) {
 			outRect.set(

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/domain/PageLoader.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/domain/PageLoader.kt
@@ -3,6 +3,8 @@ package org.koitharu.kotatsu.reader.domain
 import android.content.Context
 import android.graphics.Rect
 import android.net.Uri
+import android.net.NetworkCapabilities
+import android.os.Build
 import androidx.annotation.AnyThread
 import androidx.annotation.CheckResult
 import androidx.collection.LongSparseArray
@@ -49,6 +51,7 @@ import org.koitharu.kotatsu.core.util.MimeTypes
 import org.koitharu.kotatsu.core.util.ext.URI_SCHEME_ZIP
 import org.koitharu.kotatsu.core.util.ext.cancelChildrenAndJoin
 import org.koitharu.kotatsu.core.util.ext.compressToPNG
+import org.koitharu.kotatsu.core.util.ext.connectivityManager
 import org.koitharu.kotatsu.core.util.ext.ensureRamAtLeast
 import org.koitharu.kotatsu.core.util.ext.ensureSuccess
 import org.koitharu.kotatsu.core.util.ext.getCompletionResultOrNull
@@ -104,7 +107,8 @@ class PageLoader @Inject constructor(
 	private var repository: MangaRepository? = null
 	private val prefetchQueue = LinkedList<MangaPage>()
 	private val counter = AtomicInteger(0)
-	private var prefetchQueueLimit = PREFETCH_LIMIT_DEFAULT // TODO adaptive
+	private val prefetchQueueLimit: Int
+		get() = computeAdaptivePrefetchLimit()
 	private val edgeDetector = EdgeDetector(context)
 
 	fun isPrefetchApplicable(): Boolean {
@@ -312,6 +316,40 @@ class PageLoader @Inject constructor(
 		return context.ramAvailable <= FileSize.MEGABYTES.convert(PREFETCH_MIN_RAM_MB, FileSize.BYTES)
 	}
 
+	/**
+	 * Computes adaptive prefetch queue limit based on:
+	 * - Available RAM: More RAM = larger queue
+	 * - Network type: Unmetered (WiFi) = larger queue, metered (cellular) = smaller queue
+	 * - Power save mode: Reduced prefetch when active
+	 */
+	private fun computeAdaptivePrefetchLimit(): Int {
+		// Base limit from RAM availability
+		val ramBytes = context.ramAvailable
+		val ramBasedLimit = when {
+			ramBytes >= FileSize.MEGABYTES.convert(512, FileSize.BYTES) -> PREFETCH_LIMIT_HIGH
+			ramBytes >= FileSize.MEGABYTES.convert(256, FileSize.BYTES) -> PREFETCH_LIMIT_DEFAULT
+			ramBytes >= FileSize.MEGABYTES.convert(128, FileSize.BYTES) -> PREFETCH_LIMIT_LOW
+			else -> PREFETCH_LIMIT_MINIMUM
+		}
+
+		// Adjust based on network conditions
+		val networkMultiplier = if (isNetworkUnmetered()) 1.0f else 0.5f
+
+		// Adjust for power save mode
+		val powerMultiplier = if (context.isPowerSaveMode()) 0.5f else 1.0f
+
+		return (ramBasedLimit * networkMultiplier * powerMultiplier)
+			.toInt()
+			.coerceIn(PREFETCH_LIMIT_MINIMUM, PREFETCH_LIMIT_HIGH)
+	}
+
+	private fun isNetworkUnmetered(): Boolean {
+		val cm = context.connectivityManager
+		val network = cm.activeNetwork ?: return false
+		val capabilities = cm.getNetworkCapabilities(network) ?: return false
+		return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+	}
+
 	private fun Image.toImageSource(): ImageSource = if (this is BitmapImage) {
 		ImageSource.cachedBitmap(toBitmap())
 	} else {
@@ -335,7 +373,10 @@ class PageLoader @Inject constructor(
 	companion object {
 
 		private const val PROGRESS_UNDEFINED = -1f
+		private const val PREFETCH_LIMIT_MINIMUM = 2
+		private const val PREFETCH_LIMIT_LOW = 4
 		private const val PREFETCH_LIMIT_DEFAULT = 6
+		private const val PREFETCH_LIMIT_HIGH = 10
 		private const val PREFETCH_MIN_RAM_MB = 80L
 
 		fun createPageRequest(pageUrl: String, mangaSource: MangaSource) = Request.Builder()

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderActivity.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderActivity.kt
@@ -83,7 +83,8 @@ class ReaderActivity :
     IdlingDetector.Callback,
     ZoomControl.ZoomControlListener,
     View.OnClickListener,
-    ScrollTimerControlView.OnVisibilityChangeListener {
+    ScrollTimerControlView.OnVisibilityChangeListener,
+    ReaderMenuProvider.Callback {
 
     @Inject
     lateinit var settings: AppSettings
@@ -194,7 +195,7 @@ class ReaderActivity :
         viewModel.isZoomControlsEnabled.observe(this) {
             viewBinding.zoomControl.isVisible = it
         }
-        addMenuProvider(ReaderMenuProvider(viewModel))
+        addMenuProvider(ReaderMenuProvider(viewModel, this))
 
         observeWindowLayout()
 
@@ -205,6 +206,11 @@ class ReaderActivity :
     override fun getParentActivityIntent(): Intent? {
         val manga = viewModel.getMangaOrNull() ?: return null
         return AppRouter.detailsIntent(this, manga)
+    }
+
+    override fun onOpenMangaInfo() {
+        val manga = viewModel.getMangaOrNull() ?: return
+        router.openDetails(manga)
     }
 
     override fun onUserInteraction() {

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderMenuProvider.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderMenuProvider.kt
@@ -8,7 +8,12 @@ import org.koitharu.kotatsu.R
 
 class ReaderMenuProvider(
 	private val viewModel: ReaderViewModel,
+	private val callback: Callback? = null,
 ) : MenuProvider {
+
+	interface Callback {
+		fun onOpenMangaInfo()
+	}
 
 	override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
 		menuInflater.inflate(R.menu.opt_reader, menu)
@@ -17,7 +22,7 @@ class ReaderMenuProvider(
 	override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
 		return when (menuItem.itemId) {
 			R.id.action_info -> {
-				// TODO
+				callback?.onOpenMangaInfo()
 				true
 			}
 

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderViewModel.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/ReaderViewModel.kt
@@ -340,7 +340,10 @@ class ReaderViewModel @Inject constructor(
             prevJob?.cancelAndJoin()
             loadingJob?.join()
             if (pages.size != content.value.pages.size) {
-                return@launchJob // TODO
+                // Pages changed during coroutine execution - the position indices are now stale.
+                // A new onCurrentPageChanged call will occur with the updated page list,
+                // so we safely discard this stale update.
+                return@launchJob
             }
             val centerPos = (lowerPos + upperPos) / 2
             pages.getOrNull(centerPos)?.let { page ->

--- a/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/BasePageHolder.kt
+++ b/app/src/main/kotlin/org/koitharu/kotatsu/reader/ui/pager/BasePageHolder.kt
@@ -142,7 +142,10 @@ abstract class BasePageHolder<B : ViewBinding>(
 	}
 
 	override fun onTrimMemory(level: Int) {
-		// TODO
+		when {
+			level >= ComponentCallbacks2.TRIM_MEMORY_MODERATE -> ssiv.recycle()
+			level >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND -> ssiv.applyDownSampling(isForeground = false)
+		}
 	}
 
 	override fun onConfigurationChanged(newConfig: Configuration) = Unit

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -416,6 +416,7 @@
     <string name="address">Address</string>
     <string name="port">Port</string>
     <string name="proxy">Proxy</string>
+    <string name="proxy_webview_not_supported">Proxy for WebView is not supported on this device</string>
     <string name="invalid_value_message">Invalid value</string>
     <string name="kitsu" translatable="false">Kitsu</string>
     <string name="email_password_enter_hint">Enter your email and password to continue</string>

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,6 @@ plugins {
 	alias(libs.plugins.hilt) apply false
 	alias(libs.plugins.ksp) apply false
 	alias(libs.plugins.room) apply false
-	alias(libs.plugins.kotlinx.serizliation) apply false
+	alias(libs.plugins.kotlinx.serialization) apply false
 //	alias(libs.plugins.decoroutinator) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -122,7 +122,7 @@ androidx-window = { module = "androidx.window:window", version.ref = "window" }
 android-application = { id = "com.android.application", version.ref = "gradle" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "dagger" }
 kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlinx-serizliation = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 room = { id = "androidx.room", version.ref = "room" }
 decoroutinator = { id = "dev.reformator.stacktracedecoroutinator", version.ref = "decoroutinator" }


### PR DESCRIPTION
- Refactor shareFile() to detect files vs directories
- Add shareSingleFile() for individual file sharing with proper MIME types
- Add shareDirectory() to share all files in a directory as multiple streams
- Support CBZ, CBR, ZIP file types with appropriate MIME types
- Filter hidden files when sharing directory contents
- Add new MIME type constants: TYPE_CBR, TYPE_ZIP, TYPE_OCTET_STREAM

This allows sharing local manga stored as directories (containing images) in addition to the existing CBZ file support.